### PR TITLE
Get cluster_name from service account options, not data

### DIFF
--- a/src/plugin/manager/cost_manager.py
+++ b/src/plugin/manager/cost_manager.py
@@ -76,8 +76,6 @@ class CostManager(BaseManager):
                 promql_query_range, start, service_account_id, secret_data
             )
 
-            # _LOGGER.debug(f"PromQL Response: {promql_response}")
-
             if promql_response:
                 response_stream = self.mimir_connector.get_cost_data(promql_response)
 
@@ -186,7 +184,6 @@ class CostManager(BaseManager):
 
     @staticmethod
     def _make_additional_info(result: dict, service_account_id: str) -> dict:
-        print(result)
         additional_info = {
             "Cluster": result["metric"].get("cluster", ""),
             "Node": result["metric"].get("node", "Unmounted PVs"),


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
In `get_tasks`, the `cluster_name` was previously obtained from the SpaceONE Service Account Information, i.e., `data`. 

However, with the development of the SpaceONE Service Account Agent mode, the code has been modified to retrieve the `cluster_name` from `options`.
